### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL scheme check

### DIFF
--- a/.changeset/fix-incomplete-url-scheme-check.md
+++ b/.changeset/fix-incomplete-url-scheme-check.md
@@ -1,0 +1,5 @@
+---
+"@unimetrics/landing": patch
+---
+
+fix incomplete URL scheme check in getPermalink to block dangerous schemes (javascript:, data:, vbscript:)

--- a/landing/src/utils/permalinks.ts
+++ b/landing/src/utils/permalinks.ts
@@ -43,12 +43,14 @@ export const getCanonical = (path = ""): string | URL => {
 export const getPermalink = (slug = "", type = "page"): string => {
   let permalink: string;
 
+  const normalizedSlug = slug.trim().toLowerCase();
+
+  // Allow fully-qualified URLs and fragment identifiers to pass through unchanged.
   if (
-    slug.startsWith("https://") ||
-    slug.startsWith("http://") ||
-    slug.startsWith("://") ||
-    slug.startsWith("#") ||
-    slug.startsWith("javascript:")
+    normalizedSlug.startsWith("https://") ||
+    normalizedSlug.startsWith("http://") ||
+    normalizedSlug.startsWith("://") ||
+    normalizedSlug.startsWith("#")
   ) {
     return slug;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/unimetrics/frontend-monorepo/security/code-scanning/2](https://github.com/unimetrics/frontend-monorepo/security/code-scanning/2)

In general, the problem is that `getPermalink` special‑cases some schemes by returning the `slug` verbatim, but it only blocks `javascript:` and ignores other executable schemes like `data:` and `vbscript:`. The safest fix is to normalize the `slug` (trim leading whitespace and lower-case a copy used for checks) and then reject any potentially dangerous schemes (`javascript:`, `data:`, `vbscript:`) instead of allowing them to be returned.

The best minimal‑change fix here is:
- Introduce a local normalized copy of `slug` (e.g. `const normalizedSlug = slug.trim().toLowerCase();`).
- Use that normalized value for the scheme checks in the initial `if` block.
- Extend the checks so that:
  - Trusted / allowed schemes (`https://`, `http://`, `://`, `#`) still cause `getPermalink` to return the original `slug` unchanged (to avoid altering existing behavior).
  - Potentially dangerous schemes (`javascript:`, `data:`, `vbscript:`) no longer pass through. For backward compatibility with the existing intent, we should avoid returning such URLs at all; a common pattern is to fall through to the normal permalink logic or, more conservatively, to return a safe placeholder. However, since `getPermalink` always returns a string and is used to generate internal paths, the least intrusive change is to simply *not* treat them as special and let them go through the switch/permalink logic rather than return them directly.
- To minimize behavior change, we can explicitly return the `slug` only when `normalizedSlug` starts with the currently allowed schemes (`https://`, `http://`, `://`, `#`) and remove `javascript:` from the “return‑as‑is” list, so `javascript:`, `data:`, and `vbscript:` never get returned directly.

All required changes are localized to the initial `if` in `getPermalink` in `landing/src/utils/permalinks.ts`; no new imports or helper functions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
